### PR TITLE
URL Cleanup

### DIFF
--- a/priv/erlang_vm.schema
+++ b/priv/erlang_vm.schema
@@ -140,7 +140,7 @@
 %% memory.
 %%
 %% More information at:
-%% http://www.erlang.org/doc/man/erlang.html#system_flag-2
+%% https://www.erlang.org/doc/man/erlang.html#system_flag-2
 {mapping, "erlang.fullsweep_after", "vm_args.-env ERL_FULLSWEEP_AFTER", [
   {default, 0},
   {datatype, integer},
@@ -180,7 +180,7 @@
 %% 32MB may not be sufficient for some workloads and is a suggested
 %% starting point. Erlangers may know this as +zdbbl.
 %% The Erlang/OTP default is 1024 (1 megabyte).
-%% See: http://www.erlang.org/doc/man/erl.html#%2bzdbbl
+%% See: https://www.erlang.org/doc/man/erl.html#%2bzdbbl
 {mapping, "erlang.distribution_buffer_size", "vm_args.+zdbbl", [
   {datatype, bytesize},
   {commented, "32MB"},
@@ -215,7 +215,7 @@
 %% This feature is a workaround for lengthy executing native code, and
 %% native code that do not bump reductions properly.
 %%
-%% More information: http://www.erlang.org/doc/man/erl.html#+sfwi
+%% More information: https://www.erlang.org/doc/man/erl.html#+sfwi
 {mapping, "erlang.schedulers.force_wakeup_interval", "vm_args.+sfwi", [
   {commented, 500},
   {datatype, integer}
@@ -231,7 +231,7 @@
 %% schedulers run out of work will not be taken into account by the
 %% load balancing logic.
 %%
-%% More information: http://www.erlang.org/doc/man/erl.html#+scl
+%% More information: https://www.erlang.org/doc/man/erl.html#+scl
 {mapping, "erlang.schedulers.compaction_of_load", "vm_args.+scl", [
   {commented, "false"},
   {datatype, {enum, [true, false]}}
@@ -246,7 +246,7 @@
 %% try to balance scheduler utilization between schedulers. That is,
 %% strive for equal scheduler utilization on all schedulers.
 %%
-%% More information: http://www.erlang.org/doc/man/erl.html#+sub
+%% More information: https://www.erlang.org/doc/man/erl.html#+sub
 {mapping, "erlang.schedulers.utilization_balancing", "vm_args.+sub", [
   {commented, "true"},
   {datatype, {enum, [true, false]}}
@@ -259,8 +259,8 @@
 %% made on the port range; instead Erlang will listen on a random
 %% high-numbered port.
 %%
-%% More information: http://www.erlang.org/faq/how_do_i.html#id55090
-%% http://www.erlang.org/doc/man/kernel_app.html
+%% More information: https://www.erlang.org/faq/how_do_i.html#id55090
+%% https://www.erlang.org/doc/man/kernel_app.html
 {mapping, "erlang.distribution.port_range.minimum", "kernel.inet_dist_listen_min", [
   {commented, 6000},
   {datatype, integer},
@@ -276,8 +276,8 @@
 
 %% @doc Set the net_kernel's net_ticktime.
 %%
-%% More information: http://www.erlang.org/doc/man/kernel_app.html#net_ticktime
-%% and http://www.erlang.org/doc/man/net_kernel.html#set_net_ticktime-1
+%% More information: https://www.erlang.org/doc/man/kernel_app.html#net_ticktime
+%% and https://www.erlang.org/doc/man/net_kernel.html#set_net_ticktime-1
 {mapping, "erlang.distribution.net_ticktime", "vm_args.-kernel net_ticktime", [
   {commented, 60},
   {datatype, integer},

--- a/src/cuttlefish_escript.erl
+++ b/src/cuttlefish_escript.erl
@@ -244,7 +244,7 @@ generate(ParsedArgs) ->
         {true, true} ->
             lager:info("~s and ~s exists, disabling cuttlefish.", [ExistingAppConfigName, ExistingVMArgsName]),
             lager:info("If you'd like to know more about cuttlefish, check your local library!", []),
-            lager:info(" or see http://github.com/basho/cuttlefish", []),
+            lager:info(" or see https://github.com/basho/cuttlefish", []),
             {ExistingAppConfigName, ExistingVMArgsName};
         {true, false} ->
             lager:info("~s exists, generating vm.args", [ExistingAppConfigName]),

--- a/src/cuttlefish_util.erl
+++ b/src/cuttlefish_util.erl
@@ -100,7 +100,7 @@ ceiling(X) ->
     end.
 
 %% Levenshtein code by Adam Lindberg, Fredrik Svensson via
-%% http://www.trapexit.org/String_similar_to_(Levenshtein)
+%% https://erlangcentral.org/wiki/index.php/String_similar_to_(Levenshtein)
 %%
 %%------------------------------------------------------------------------------
 %% @spec levenshtein(StringA :: string(), StringB :: string()) -> integer()

--- a/test/riak.schema
+++ b/test/riak.schema
@@ -1187,7 +1187,7 @@ end}.
 %% 32mb may not be sufficient for some workloads and is a suggested
 %% starting point.
 %% The Erlang/OTP default is 1024 (1 megabyte).
-%% See: http://www.erlang.org/doc/man/erl.html#%2bzdbbl
+%% See: https://www.erlang.org/doc/man/erl.html#%2bzdbbl
 {mapping, "erlang.zdouble", "vm_args.+zdbbl", [
   {commented, "32MB"},
   {datatype, bytesize}


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* http://erlang.org/doc/man/erl.html (200) with 4 occurrences could not be migrated:  
   ([https](https://erlang.org/doc/man/erl.html) result ConnectTimeoutException).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://github.com/basho/cuttlefish with 1 occurrences migrated to:  
  https://github.com/basho/cuttlefish ([https](https://github.com/basho/cuttlefish) result 200).
* http://www.trapexit.org/String_similar_to_ (302) with 1 occurrences migrated to:  
  https://erlangcentral.org/wiki/index.php/String_similar_to_ ([https](https://www.trapexit.org/String_similar_to_) result 301).
* http://www.erlang.org/doc/man/erl.html with 5 occurrences migrated to:  
  https://www.erlang.org/doc/man/erl.html ([https](https://www.erlang.org/doc/man/erl.html) result 301).
* http://www.erlang.org/doc/man/erlang.html with 1 occurrences migrated to:  
  https://www.erlang.org/doc/man/erlang.html ([https](https://www.erlang.org/doc/man/erlang.html) result 301).
* http://www.erlang.org/doc/man/kernel_app.html with 2 occurrences migrated to:  
  https://www.erlang.org/doc/man/kernel_app.html ([https](https://www.erlang.org/doc/man/kernel_app.html) result 301).
* http://www.erlang.org/doc/man/net_kernel.html with 1 occurrences migrated to:  
  https://www.erlang.org/doc/man/net_kernel.html ([https](https://www.erlang.org/doc/man/net_kernel.html) result 301).
* http://www.erlang.org/faq/how_do_i.html with 1 occurrences migrated to:  
  https://www.erlang.org/faq/how_do_i.html ([https](https://www.erlang.org/faq/how_do_i.html) result 301).