### PR TITLE
URL Cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@
 # except in compliance with the License.  You may obtain
 # a copy of the License at
 #
-#   http://www.apache.org/licenses/LICENSE-2.0
+#   https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/rebar.config
+++ b/rebar.config
@@ -8,7 +8,7 @@
 %% except in compliance with the License.  You may obtain
 %% a copy of the License at
 %%
-%%   http://www.apache.org/licenses/LICENSE-2.0
+%%   https://www.apache.org/licenses/LICENSE-2.0
 %%
 %% Unless required by applicable law or agreed to in writing,
 %% software distributed under the License is distributed on an

--- a/src/conf_parse.peg
+++ b/src/conf_parse.peg
@@ -7,7 +7,7 @@
 %% except in compliance with the License.  You may obtain
 %% a copy of the License at
 %%
-%%   http://www.apache.org/licenses/LICENSE-2.0
+%%   https://www.apache.org/licenses/LICENSE-2.0
 %%
 %% Unless required by applicable law or agreed to in writing,
 %% software distributed under the License is distributed on an
@@ -87,7 +87,7 @@ ws <- [ \t] `ws`;
 %% except in compliance with the License.  You may obtain
 %% a copy of the License at
 %%
-%%   http://www.apache.org/licenses/LICENSE-2.0
+%%   https://www.apache.org/licenses/LICENSE-2.0
 %%
 %% Unless required by applicable law or agreed to in writing,
 %% software distributed under the License is distributed on an

--- a/src/cuttlefish.erl
+++ b/src/cuttlefish.erl
@@ -9,7 +9,7 @@
 %% except in compliance with the License.  You may obtain
 %% a copy of the License at
 %%
-%%   http://www.apache.org/licenses/LICENSE-2.0
+%%   https://www.apache.org/licenses/LICENSE-2.0
 %%
 %% Unless required by applicable law or agreed to in writing,
 %% software distributed under the License is distributed on an

--- a/src/cuttlefish_advanced.erl
+++ b/src/cuttlefish_advanced.erl
@@ -9,7 +9,7 @@
 %% except in compliance with the License.  You may obtain
 %% a copy of the License at
 %%
-%%   http://www.apache.org/licenses/LICENSE-2.0
+%%   https://www.apache.org/licenses/LICENSE-2.0
 %%
 %% Unless required by applicable law or agreed to in writing,
 %% software distributed under the License is distributed on an

--- a/src/cuttlefish_bytesize.erl
+++ b/src/cuttlefish_bytesize.erl
@@ -9,7 +9,7 @@
 %% except in compliance with the License.  You may obtain
 %% a copy of the License at
 %%
-%%   http://www.apache.org/licenses/LICENSE-2.0
+%%   https://www.apache.org/licenses/LICENSE-2.0
 %%
 %% Unless required by applicable law or agreed to in writing,
 %% software distributed under the License is distributed on an

--- a/src/cuttlefish_conf.erl
+++ b/src/cuttlefish_conf.erl
@@ -7,7 +7,7 @@
 %% except in compliance with the License.  You may obtain
 %% a copy of the License at
 %%
-%%   http://www.apache.org/licenses/LICENSE-2.0
+%%   https://www.apache.org/licenses/LICENSE-2.0
 %%
 %% Unless required by applicable law or agreed to in writing,
 %% software distributed under the License is distributed on an

--- a/src/cuttlefish_datatypes.erl
+++ b/src/cuttlefish_datatypes.erl
@@ -9,7 +9,7 @@
 %% except in compliance with the License.  You may obtain
 %% a copy of the License at
 %%
-%%   http://www.apache.org/licenses/LICENSE-2.0
+%%   https://www.apache.org/licenses/LICENSE-2.0
 %%
 %% Unless required by applicable law or agreed to in writing,
 %% software distributed under the License is distributed on an

--- a/src/cuttlefish_duration.erl
+++ b/src/cuttlefish_duration.erl
@@ -9,7 +9,7 @@
 %% except in compliance with the License.  You may obtain
 %% a copy of the License at
 %%
-%%   http://www.apache.org/licenses/LICENSE-2.0
+%%   https://www.apache.org/licenses/LICENSE-2.0
 %%
 %% Unless required by applicable law or agreed to in writing,
 %% software distributed under the License is distributed on an

--- a/src/cuttlefish_duration_parse.peg
+++ b/src/cuttlefish_duration_parse.peg
@@ -34,7 +34,7 @@ float <- ( [0-9]+ "." [0-9]+ ) / ( "." [0-9]+ ) `
 %% except in compliance with the License.  You may obtain
 %% a copy of the License at
 %%
-%%   http://www.apache.org/licenses/LICENSE-2.0
+%%   https://www.apache.org/licenses/LICENSE-2.0
 %%
 %% Unless required by applicable law or agreed to in writing,
 %% software distributed under the License is distributed on an

--- a/src/cuttlefish_effective.erl
+++ b/src/cuttlefish_effective.erl
@@ -9,7 +9,7 @@
 %% except in compliance with the License.  You may obtain
 %% a copy of the License at
 %%
-%%   http://www.apache.org/licenses/LICENSE-2.0
+%%   https://www.apache.org/licenses/LICENSE-2.0
 %%
 %% Unless required by applicable law or agreed to in writing,
 %% software distributed under the License is distributed on an

--- a/src/cuttlefish_enum.erl
+++ b/src/cuttlefish_enum.erl
@@ -10,7 +10,7 @@
 %% except in compliance with the License.  You may obtain
 %% a copy of the License at
 %%
-%%   http://www.apache.org/licenses/LICENSE-2.0
+%%   https://www.apache.org/licenses/LICENSE-2.0
 %%
 %% Unless required by applicable law or agreed to in writing,
 %% software distributed under the License is distributed on an

--- a/src/cuttlefish_error.erl
+++ b/src/cuttlefish_error.erl
@@ -9,7 +9,7 @@
 %% except in compliance with the License.  You may obtain
 %% a copy of the License at
 %%
-%%   http://www.apache.org/licenses/LICENSE-2.0
+%%   https://www.apache.org/licenses/LICENSE-2.0
 %%
 %% Unless required by applicable law or agreed to in writing,
 %% software distributed under the License is distributed on an

--- a/src/cuttlefish_escript.erl
+++ b/src/cuttlefish_escript.erl
@@ -9,7 +9,7 @@
 %% except in compliance with the License.  You may obtain
 %% a copy of the License at
 %%
-%%   http://www.apache.org/licenses/LICENSE-2.0
+%%   https://www.apache.org/licenses/LICENSE-2.0
 %%
 %% Unless required by applicable law or agreed to in writing,
 %% software distributed under the License is distributed on an

--- a/src/cuttlefish_flag.erl
+++ b/src/cuttlefish_flag.erl
@@ -10,7 +10,7 @@
 %% except in compliance with the License.  You may obtain
 %% a copy of the License at
 %%
-%%   http://www.apache.org/licenses/LICENSE-2.0
+%%   https://www.apache.org/licenses/LICENSE-2.0
 %%
 %% Unless required by applicable law or agreed to in writing,
 %% software distributed under the License is distributed on an

--- a/src/cuttlefish_generator.erl
+++ b/src/cuttlefish_generator.erl
@@ -7,7 +7,7 @@
 %% except in compliance with the License.  You may obtain
 %% a copy of the License at
 %%
-%%   http://www.apache.org/licenses/LICENSE-2.0
+%%   https://www.apache.org/licenses/LICENSE-2.0
 %%
 %% Unless required by applicable law or agreed to in writing,
 %% software distributed under the License is distributed on an

--- a/src/cuttlefish_mapping.erl
+++ b/src/cuttlefish_mapping.erl
@@ -9,7 +9,7 @@
 %% except in compliance with the License.  You may obtain
 %% a copy of the License at
 %%
-%%   http://www.apache.org/licenses/LICENSE-2.0
+%%   https://www.apache.org/licenses/LICENSE-2.0
 %%
 %% Unless required by applicable law or agreed to in writing,
 %% software distributed under the License is distributed on an

--- a/src/cuttlefish_rebar_plugin.erl
+++ b/src/cuttlefish_rebar_plugin.erl
@@ -7,7 +7,7 @@
 %% except in compliance with the License.  You may obtain
 %% a copy of the License at
 %%
-%%   http://www.apache.org/licenses/LICENSE-2.0
+%%   https://www.apache.org/licenses/LICENSE-2.0
 %%
 %% Unless required by applicable law or agreed to in writing,
 %% software distributed under the License is distributed on an

--- a/src/cuttlefish_schema.erl
+++ b/src/cuttlefish_schema.erl
@@ -7,7 +7,7 @@
 %% except in compliance with the License.  You may obtain
 %% a copy of the License at
 %%
-%%   http://www.apache.org/licenses/LICENSE-2.0
+%%   https://www.apache.org/licenses/LICENSE-2.0
 %%
 %% Unless required by applicable law or agreed to in writing,
 %% software distributed under the License is distributed on an

--- a/src/cuttlefish_translation.erl
+++ b/src/cuttlefish_translation.erl
@@ -7,7 +7,7 @@
 %% except in compliance with the License.  You may obtain
 %% a copy of the License at
 %%
-%%   http://www.apache.org/licenses/LICENSE-2.0
+%%   https://www.apache.org/licenses/LICENSE-2.0
 %%
 %% Unless required by applicable law or agreed to in writing,
 %% software distributed under the License is distributed on an

--- a/src/cuttlefish_unit.erl
+++ b/src/cuttlefish_unit.erl
@@ -7,7 +7,7 @@
 %% except in compliance with the License.  You may obtain
 %% a copy of the License at
 %%
-%%   http://www.apache.org/licenses/LICENSE-2.0
+%%   https://www.apache.org/licenses/LICENSE-2.0
 %%
 %% Unless required by applicable law or agreed to in writing,
 %% software distributed under the License is distributed on an

--- a/src/cuttlefish_util.erl
+++ b/src/cuttlefish_util.erl
@@ -9,7 +9,7 @@
 %% except in compliance with the License.  You may obtain
 %% a copy of the License at
 %%
-%%   http://www.apache.org/licenses/LICENSE-2.0
+%%   https://www.apache.org/licenses/LICENSE-2.0
 %%
 %% Unless required by applicable law or agreed to in writing,
 %% software distributed under the License is distributed on an

--- a/src/cuttlefish_validator.erl
+++ b/src/cuttlefish_validator.erl
@@ -9,7 +9,7 @@
 %% except in compliance with the License.  You may obtain
 %% a copy of the License at
 %%
-%%   http://www.apache.org/licenses/LICENSE-2.0
+%%   https://www.apache.org/licenses/LICENSE-2.0
 %%
 %% Unless required by applicable law or agreed to in writing,
 %% software distributed under the License is distributed on an

--- a/src/cuttlefish_variable.erl
+++ b/src/cuttlefish_variable.erl
@@ -9,7 +9,7 @@
 %% except in compliance with the License.  You may obtain
 %% a copy of the License at
 %%
-%%   http://www.apache.org/licenses/LICENSE-2.0
+%%   https://www.apache.org/licenses/LICENSE-2.0
 %%
 %% Unless required by applicable law or agreed to in writing,
 %% software distributed under the License is distributed on an

--- a/src/lager_stderr_backend.erl
+++ b/src/lager_stderr_backend.erl
@@ -5,7 +5,7 @@
 %% except in compliance with the License.  You may obtain
 %% a copy of the License at
 %%
-%%   http://www.apache.org/licenses/LICENSE-2.0
+%%   https://www.apache.org/licenses/LICENSE-2.0
 %%
 %% Unless required by applicable law or agreed to in writing,
 %% software distributed under the License is distributed on an

--- a/test/cuttlefish_escript_integration_tests.erl
+++ b/test/cuttlefish_escript_integration_tests.erl
@@ -7,7 +7,7 @@
 %% except in compliance with the License.  You may obtain
 %% a copy of the License at
 %%
-%%   http://www.apache.org/licenses/LICENSE-2.0
+%%   https://www.apache.org/licenses/LICENSE-2.0
 %%
 %% Unless required by applicable law or agreed to in writing,
 %% software distributed under the License is distributed on an

--- a/test/cuttlefish_escript_test.erl
+++ b/test/cuttlefish_escript_test.erl
@@ -7,7 +7,7 @@
 %% except in compliance with the License.  You may obtain
 %% a copy of the License at
 %%
-%%   http://www.apache.org/licenses/LICENSE-2.0
+%%   https://www.apache.org/licenses/LICENSE-2.0
 %%
 %% Unless required by applicable law or agreed to in writing,
 %% software distributed under the License is distributed on an

--- a/test/cuttlefish_integration_test.erl
+++ b/test/cuttlefish_integration_test.erl
@@ -7,7 +7,7 @@
 %% except in compliance with the License.  You may obtain
 %% a copy of the License at
 %%
-%%   http://www.apache.org/licenses/LICENSE-2.0
+%%   https://www.apache.org/licenses/LICENSE-2.0
 %%
 %% Unless required by applicable law or agreed to in writing,
 %% software distributed under the License is distributed on an

--- a/test/cuttlefish_test_group_leader.erl
+++ b/test/cuttlefish_test_group_leader.erl
@@ -7,7 +7,7 @@
 %% except in compliance with the License.  You may obtain
 %% a copy of the License at
 %%
-%%   http://www.apache.org/licenses/LICENSE-2.0
+%%   https://www.apache.org/licenses/LICENSE-2.0
 %%
 %% Unless required by applicable law or agreed to in writing,
 %% software distributed under the License is distributed on an

--- a/test/cuttlefish_test_util.erl
+++ b/test/cuttlefish_test_util.erl
@@ -7,7 +7,7 @@
 %% except in compliance with the License.  You may obtain
 %% a copy of the License at
 %%
-%%   http://www.apache.org/licenses/LICENSE-2.0
+%%   https://www.apache.org/licenses/LICENSE-2.0
 %%
 %% Unless required by applicable law or agreed to in writing,
 %% software distributed under the License is distributed on an


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 31 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).